### PR TITLE
[DP-590] Kubespawner에서 headless service 생성

### DIFF
--- a/kubespawner/objects.py
+++ b/kubespawner/objects.py
@@ -447,7 +447,7 @@ def make_service(
 
     service.spec = V1ServiceSpec()
 
-    service.spec.selector = selectors
+    service.spec.selector = selectors.copy()
     service.spec.ports = [V1ServicePort(**port) for port in ports]
 
     return service

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ if v[:2] < (3, 5):
 
 setup(
     name='jupyterhub-kubespawner',
-    version='0.10.1.dev',
+    version='0.10.1.devsisters',
     install_requires=[
         'jupyterhub>=0.8',
         'pyYAML',


### PR DESCRIPTION
* Jupyterhub에서 각 사용자에게 jupyter notebook을 띄워 줄 때 개별적으로 pod을 띄워주는데, 이 때 spark를 해당 pod에서 띄우기 위해서는 spark master를 select하는 service를 띄워줘야 함 (https://spark.apache.org/docs/latest/running-on-kubernetes.html#client-mode-networking)
* 따라서 Service를 띄우기 위한 추가적인 config option (spark-on-k8s에 관련 PR 제출 예정)을 설정하도록 변경
* 기존 kubespawner에서는 image 리스트만 선택할 수 있었으나 env profile option을 추가하여 spark executor option 등을 조절할 수 있도록 변경

* NOTE: 이를 위해서는 jupyterhub helm 차트에서 생성하는 service account에서 service를 생성할 수 있는 권한을 주어야 함. 따라서 chart도 별도로 fork해서 수정해야 하는 부담(?) 이 있음. 좋은 방안 있으면 공유 부탁드리겠습니다.